### PR TITLE
Add service sites

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -104,6 +104,7 @@
     <script type="text/javascript" src="/lib/js.cookie.js"></script>
     <script type="text/javascript" src="/lib/clipboard.min.js"></script>
     <script type="text/javascript" src="/lib/printThis.js"></script>
+    <script type="text/javascript" src="/lib/jquery.bs.gdpr.cookies.js"></script>
     <script type="text/javascript" src="/js/analytics_lib.js"></script>
     <script type="text/javascript" src="/js/cartodb_lib.js"></script>
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -367,11 +367,11 @@ div#modal-image { padding: 0; }
 
 /* GDPR modal */
 #bs-gdpr-cookies-modal {
-  font-size: 18px;
+  font-size: 16px;
 }
 
 #bs-gdpr-cookies-modal h5 {
-  font-size: 22px;
+  font-size: 20px;
 }
 
 #bs-gdpr-cookies-modal .modal-footer {

--- a/css/custom.css
+++ b/css/custom.css
@@ -113,7 +113,7 @@ img {
 }
 
 .nav-tabs>li>a {
-  background-color: #dddddd;
+  background-color: #C7C7C7;
   color: #fff;
 }
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -108,6 +108,24 @@ img {
 }
 
 /* Filters */
+.tab-pane {
+  padding: 12px;
+}
+
+.nav-tabs>li>a {
+  background-color: #dddddd;
+  color: #fff;
+}
+
+.nav-tabs {
+  padding-top: 10px;
+}
+
+.nav-tabs>li.active>a, .nav-tabs>li.active>a:hover, .nav-tabs>li.active>a:focus {
+  background-color: #0A5193;
+  color: #fff; 
+}
+
 .form-control {
   height: 36px;
   padding: 6px 12px;

--- a/css/custom.css
+++ b/css/custom.css
@@ -159,13 +159,13 @@ button:focus, .btn:focus, .btn:active:focus, .btn.active:focus, .btn.focus, .btn
   border-color: #FF474E;
 }
 
-.btn-reset, .label {
+.btn-reset, .btn-primary, .label {
   color: #ffffff;
   background-color: #5187BB;
   border-color: #5187BB;
 }
 
-.btn-reset:hover {
+.btn-primary:hover, .btn-reset:hover {
   background-color: #6C9AC6;
   border-color: #6C9AC6;
 }
@@ -359,6 +359,20 @@ div#modal-image { padding: 0; }
               text-align: center;
        }
     }
+
+
+/* GDPR modla */
+#bs-gdpr-cookies-modal {
+  font-size: 18px;
+}
+
+#bs-gdpr-cookies-modal h5 {
+  font-size: 22px;
+}
+
+#bs-gdpr-cookies-modal .modal-footer {
+  border-top: 0;
+}
 
 /* About */
 .well-affixed {

--- a/css/custom.css
+++ b/css/custom.css
@@ -30,6 +30,10 @@ img {
   margin-top: 2em;
 }
 
+.mg-bottom-lg {
+  margin-bottom: 3em;
+}
+
 /* Navbar */
 .navbar {
   margin-bottom: 10px;

--- a/css/custom.css
+++ b/css/custom.css
@@ -203,6 +203,11 @@ button:focus, .btn:focus, .btn:active:focus, .btn.active:focus, .btn.focus, .btn
   display: none;
 }
 
+.select2-container--default.select2-container--focus .select2-selection--multiple {
+    border: solid #aaa 1px;
+    border-left: 0;
+}
+
 /* Map map */
 #mapCanvas img {
   max-width: none;

--- a/css/custom.css
+++ b/css/custom.css
@@ -361,7 +361,7 @@ div#modal-image { padding: 0; }
     }
 
 
-/* GDPR modla */
+/* GDPR modal */
 #bs-gdpr-cookies-modal {
   font-size: 18px;
 }

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ layout: default
 
     </div>
 
-    <p><strong>Filter your search.</strong> Click on each filter to view a list of options. You can select more than one.</p>
+    <p><strong>Filter probation resources.</strong> Click on each filter to view a list of options. You can select more than one.</p>
 
     <div>
       <div class="input-group select2-bootstrap-prepend">
@@ -72,7 +72,7 @@ layout: default
     <!-- APD community service sites filters -->
     <div class="row">
       <div class="col-xs-12">
-        <p><strong>Filter for APD community service sites.</strong> You cannot filter by age, language, fcaility, programs, or payment preferences.</p>
+        <p><strong>Filter for APD community service sites.</strong> You cannot filter by age, language, facility, programs, or payment preferences.</p>
         <div class="checkbox">
           <label>
             <p><input id="communitySite" type="checkbox">Show only APD community service sites</p>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<div class='row'>
+<div class='row mg-bottom-lg'>
   <div class="col-md-4">
     <p>Find resources near you for adults and juveniles on probation in Cook County</p>
 

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@ layout: default
           <div class="col-md-6">
             <div class="checkbox">
               <label>
-                <p><input id="handicapAccessible" type="checkbox">Accepts sex offenders</p>
+                <p><input id="acceptsSexOffenders" type="checkbox">Accepts sex offenders</p>
               </label>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,11 @@ layout: default
             <p><input id="lgbtq" type="checkbox">Show only facilities that specialize with LGBTQ</p>
           </label>
         </div>
+        <div class="checkbox">
+          <label>
+            <p><input id="communitySite" type="checkbox">Show only APD community service sites</p>
+          </label>
+        </div>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -66,6 +66,13 @@ layout: default
             <p><input id="lgbtq" type="checkbox">Show only facilities that specialize with LGBTQ</p>
           </label>
         </div>
+      </div>
+    </div>
+
+    <!-- APD community service sites filters -->
+    <div class="row">
+      <div class="col-xs-12">
+        <p><strong>Filter for APD community service sites.</strong> You cannot filter by age, language, fcaility, programs, or payment preferences.</p>
         <div class="checkbox">
           <label>
             <p><input id="communitySite" type="checkbox">Show only APD community service sites</p>
@@ -73,20 +80,18 @@ layout: default
         </div>
       </div>
     </div>
-
-    <!-- TODO: Make this a panel that opens and closes, based on the value of communitySite checkbox -->
-    <div class="row">
+    <!-- Panel made visible after clicking #communitySite -->
+    <div class="row apd-filters hidden">
       <div class="col-xs-12">
-        <p><strong>Filter community service sites further.</strong></p>
         <div class="row">
-          <div class="col-md-6">
+          <div class="col-md-4">
             <div class="checkbox">
               <label>
                 <p><input id="handicapAccessible" type="checkbox">Handicap accessible</p>
               </label>
             </div>
           </div>
-          <div class="col-md-6">
+          <div class="col-md-8">
             <div class="checkbox">
               <label>
                 <p><input id="acceptsSexOffenders" type="checkbox">Accepts sex offenders</p>

--- a/index.html
+++ b/index.html
@@ -74,6 +74,29 @@ layout: default
       </div>
     </div>
 
+    <!-- TODO: Make this a panel that opens and closes, based on the value of communitySite checkbox -->
+    <div class="row">
+      <div class="col-xs-12">
+        <p><strong>Filter community service sites further.</strong></p>
+        <div class="row">
+          <div class="col-md-6">
+            <div class="checkbox">
+              <label>
+                <p><input id="handicapAccessible" type="checkbox">Handicap accessible</p>
+              </label>
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="checkbox">
+              <label>
+                <p><input id="handicapAccessible" type="checkbox">Accepts sex offenders</p>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div>
       <button class='btn btn-search' id="btnSearch"><i class='fa fa-search'></i> Search</button>
       <a href="/" class='btn btn-reset' id="btnReset" data-toggle="tooltip" data-placement="bottom" title="Reset"><i class="fa fa-repeat" aria-hidden="true"></i></a>

--- a/index.html
+++ b/index.html
@@ -69,19 +69,19 @@ layout: default
       </div>
     </div>
 
-    <!-- APD community service sites filters -->
+    <!-- Community service sites filters -->
     <div class="row">
       <div class="col-xs-12">
-        <p><strong>Filter for APD community service sites.</strong> You cannot filter by age, language, facility, programs, or payment preferences.</p>
+        <p><strong>Filter for community service sites.</strong> You cannot filter by age, language, facility, programs, or payment preferences.</p>
         <div class="checkbox">
           <label>
-            <p><input id="communitySite" type="checkbox">Show only APD community service sites</p>
+            <p><input id="communitySite" type="checkbox">Show only community service sites</p>
           </label>
         </div>
       </div>
     </div>
     <!-- Panel made visible after clicking #communitySite -->
-    <div class="row apd-filters hidden">
+    <div class="row community-service-filters hidden">
       <div class="col-xs-12">
         <div class="row">
           <div class="col-md-4">

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@ layout: default
     <p>Find resources near you for adults and juveniles on probation in Cook County</p>
 
     <div class='row'>
-
       <div class="col-md-8">
         <div class="form-group">
             Address
@@ -27,80 +26,72 @@ layout: default
             </select>
         </div>
       </div>
-
     </div>
 
-    <p><strong>Filter probation resources.</strong> Click on each filter to view a list of options. You can select more than one.</p>
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs" role="tablist">
+      <li class="active probation-tab"><a href="#probation" role="tab" data-toggle="tab">Probation resources</a></li>
+      <li class="community-tab"><a href="#community-sites" role="tab" data-toggle="tab">Community sites</a></li>
+    </ul>
 
-    <div>
-      <div class="input-group select2-bootstrap-prepend">
-        <span class="input-group-addon"><i class="fa fa-user" aria-hidden="true"></i></span>
-        <select class="data-array-age form-control" id="select-age" multiple="multiple"></select>
-      </div>
+    <!-- Tab panes -->
+    <div class="tab-content">
+      <!-- Probation resources pane -->
+      <div class="tab-pane active" id="probation">
+        <p><strong>Filter probation resources.</strong> Click on each filter to view a list of options. You can select more than one.</p>
+        <div>
+          <div class="input-group select2-bootstrap-prepend">
+            <span class="input-group-addon"><i class="fa fa-user" aria-hidden="true"></i></span>
+            <select class="data-array-age form-control" id="select-age" multiple="multiple"></select>
+          </div>
 
-      <div class="input-group select2-bootstrap-prepend m-top-sm">
-        <span class="input-group-addon"><i class="fa fa-globe" aria-hidden="true"></i></span>
-        <select class="data-array-language form-control" id="select-language" multiple="multiple"></select>
-      </div>
+          <div class="input-group select2-bootstrap-prepend m-top-sm">
+            <span class="input-group-addon"><i class="fa fa-globe" aria-hidden="true"></i></span>
+            <select class="data-array-language form-control" id="select-language" multiple="multiple"></select>
+          </div>
 
-      <div class="input-group select2-bootstrap-prepend m-top-sm">
-        <span class="input-group-addon"><i class="fa fa-building-o" aria-hidden="true"></i></span>
-        <select class="data-array-type form-control" id="select-type" multiple="multiple"></select>
-      </div>
+          <div class="input-group select2-bootstrap-prepend m-top-sm">
+            <span class="input-group-addon"><i class="fa fa-building-o" aria-hidden="true"></i></span>
+            <select class="data-array-type form-control" id="select-type" multiple="multiple"></select>
+          </div>
 
-      <div class="input-group select2-bootstrap-prepend m-top-sm">
-        <span class="input-group-addon"><i class="fa fa-heart" aria-hidden="true"></i></span>
-        <select class="data-array-program form-control" id="select-program" multiple="multiple"></select>
-      </div>
+          <div class="input-group select2-bootstrap-prepend m-top-sm">
+            <span class="input-group-addon"><i class="fa fa-heart" aria-hidden="true"></i></span>
+            <select class="data-array-program form-control" id="select-program" multiple="multiple"></select>
+          </div>
 
-      <div class="input-group select2-bootstrap-prepend m-top-sm m-bottom-sm">
-        <span class="input-group-addon"><i class="fa fa-usd" aria-hidden="true"></i>&nbsp;</span>
-        <select class="data-array-insurance form-control" id="select-insurance" multiple="multiple"></select>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-xs-12">
-        <div class="checkbox">
-          <label>
-            <p><input id="lgbtq" type="checkbox">Show only facilities that specialize with LGBTQ</p>
-          </label>
+          <div class="input-group select2-bootstrap-prepend m-top-sm m-bottom-sm">
+            <span class="input-group-addon"><i class="fa fa-usd" aria-hidden="true"></i>&nbsp;</span>
+            <select class="data-array-insurance form-control" id="select-insurance" multiple="multiple"></select>
+          </div>
         </div>
-      </div>
-    </div>
 
-    <!-- Community service sites filters -->
-    <div class="row">
-      <div class="col-xs-12">
-        <p><strong>Filter for community service sites.</strong> You cannot filter by age, language, facility, programs, or payment preferences.</p>
-        <div class="checkbox">
-          <label>
-            <p><input id="communitySite" type="checkbox">Show only community service sites</p>
-          </label>
-        </div>
-      </div>
-    </div>
-    <!-- Panel made visible after clicking #communitySite -->
-    <div class="row community-service-filters hidden">
-      <div class="col-xs-12">
         <div class="row">
-          <div class="col-md-4">
+          <div class="col-xs-12">
             <div class="checkbox">
               <label>
-                <p><input id="handicapAccessible" type="checkbox">Handicap accessible</p>
-              </label>
-            </div>
-          </div>
-          <div class="col-md-8">
-            <div class="checkbox">
-              <label>
-                <p><input id="acceptsSexOffenders" type="checkbox">Accepts sex offenders</p>
+                <p><input id="lgbtq" type="checkbox">Show only facilities that specialize with LGBTQ</p>
               </label>
             </div>
           </div>
         </div>
       </div>
-    </div>
+      <!-- Commuinity sites pane -->
+      <div class="tab-pane" id="community-sites">
+        <p><strong>Filter community service sites.</strong> Add filters, or return all community service sites (excludes probation resource locations).</p>
+        <div class="checkbox">
+          <label>
+            <p><input id="handicapAccessible" type="checkbox">Handicap accessible</p>
+          </label>
+        </div>
+        <div class="checkbox">
+          <label>
+            <p><input id="acceptsSexOffenders" type="checkbox">Accepts sex offenders</p>
+          </label>
+        </div>
+      </div>
+
+    </div> <!-- End tab panes -->
 
     <div>
       <button class='btn btn-search' id="btnSearch"><i class='fa fa-search'></i> Search</button>

--- a/js/cartodb_lib.js
+++ b/js/cartodb_lib.js
@@ -626,7 +626,7 @@ var CartoDbLib = {
 
     community_site_checked = $('#communitySite').is(':checked')
     if (community_site_checked == true) {
-      CartoDbLib.userSelection += " AND LOWER(apd_community_service_site) LIKE '%yes%'";
+      CartoDbLib.userSelection += " AND apd_community_service_site = True";
       CartoDbLib.communitySiteSelection = 'true';
     } else {
       CartoDbLib.communitySiteSelection = '';

--- a/js/cartodb_lib.js
+++ b/js/cartodb_lib.js
@@ -48,10 +48,16 @@ var CartoDbLib = {
       $("#lgbtq").prop( "checked", false );
     }
 
-    if ( $.address.parameter('communitySite') ) {
-      $("#communitySite").prop( "checked", true );
+    if ( $.address.parameter('handicap') ) {
+      $("#handicapAccessible").prop( "checked", true );
     } else {
-      $("#communitySite").prop( "checked", false );
+      $("#handicapAccessible").prop( "checked", false );
+    }
+
+    if ( $.address.parameter('offenders') ) {
+      $("#acceptsSexOffenders").prop( "checked", true );
+    } else {
+      $("#acceptsSexOffenders").prop( "checked", false );
     }
 
     var num = $.address.parameter('modal_id');

--- a/js/cartodb_lib.js
+++ b/js/cartodb_lib.js
@@ -22,6 +22,7 @@ var CartoDbLib = {
   typeSelections: '',
   insuranceSelections: '',
   lgbtqSelection: '',
+  communitySiteSelection: '',
   userSelection: '',
   radius: '',
   resultsCount: 0,
@@ -42,6 +43,12 @@ var CartoDbLib = {
       $("#lgbtq").prop( "checked", true );
     } else {
       $("#lgbtq").prop( "checked", false );
+    }
+
+    if ( $.address.parameter('communitySite') ) {
+      $("#communitySite").prop( "checked", true );
+    } else {
+      $("#communitySite").prop( "checked", false );
     }
 
     var num = $.address.parameter('modal_id');
@@ -150,6 +157,7 @@ var CartoDbLib = {
           $.address.parameter('program', encodeURIComponent(CartoDbLib.programSelections));
           $.address.parameter('insure', encodeURIComponent(CartoDbLib.insuranceSelections));
           $.address.parameter('lgbtq', encodeURIComponent(CartoDbLib.lgbtqSelection));
+          $.address.parameter('communitySite', encodeURIComponent(CartoDbLib.communitySiteSelection));
 
           CartoDbLib.setZoom();
           CartoDbLib.addIcon();
@@ -174,6 +182,7 @@ var CartoDbLib = {
       $.address.parameter('program', encodeURIComponent(CartoDbLib.programSelections));
       $.address.parameter('insure', encodeURIComponent(CartoDbLib.insuranceSelections));
       $.address.parameter('lgbtq', encodeURIComponent(CartoDbLib.lgbtqSelection));
+      $.address.parameter('communitySite', encodeURIComponent(CartoDbLib.communitySiteSelection));
 
       CartoDbLib.renderMap();
       CartoDbLib.renderList();
@@ -615,6 +624,14 @@ var CartoDbLib = {
       CartoDbLib.lgbtqSelection = '';
     }
 
+    community_site_checked = $('#communitySite').is(':checked')
+    if (community_site_checked == true) {
+      CartoDbLib.userSelection += " AND LOWER(apd_community_service_site) LIKE '%yes%'";
+      CartoDbLib.communitySiteSelection = 'true';
+    } else {
+      CartoDbLib.communitySiteSelection = '';
+    }
+
     CartoDbLib.whereClause = " WHERE the_geom is not null AND ";
 
     if (CartoDbLib.geoSearch != "") {
@@ -679,6 +696,7 @@ var CartoDbLib = {
       "type": CartoDbLib.typeSelections,
       "insurance": CartoDbLib.insuranceSelections,
       "lgbtq": CartoDbLib.lgbtqSelection,
+      "communitySite": CartoDbLib.communitySiteSelection,
       "program": CartoDbLib.programSelections,
       "path": path,
       "save_name": save_name,
@@ -720,6 +738,12 @@ var CartoDbLib = {
           $("#lgbtq").prop( "checked", true );
         } else {
           $("#lgbtq").prop( "checked", false );
+        }
+
+        if (obj.communitySite != '') {
+          $("#communitySite").prop( "checked", true );
+        } else {
+          $("#communitySite").prop( "checked", false );
         }
 
         var ageArr     = CartoDbLib.makeSelectionArray(obj.age, ageOptions);

--- a/js/cartodb_lib.js
+++ b/js/cartodb_lib.js
@@ -23,6 +23,8 @@ var CartoDbLib = {
   insuranceSelections: '',
   lgbtqSelection: '',
   communitySiteSelection: '',
+  handicapAccessibleSelection: '',
+  acceptsSexOffendersSelection: '',
   userSelection: '',
   radius: '',
   resultsCount: 0,
@@ -593,43 +595,68 @@ var CartoDbLib = {
     }
 
     CartoDbLib.userSelection = '';
-    // Gets selected elements in dropdown (represented as an array of objects).
-    var ageUserSelections = ($("#select-age").select2('data'))
-    var langUserSelections = ($("#select-language").select2('data'))
-    var typeUserSelections = ($("#select-type").select2('data'))
-    var programUserSelections = ($("#select-program").select2('data'))
-    var insuranceUserSelections = ($("#select-insurance").select2('data'))
 
-    // Set results equal to varaible – to be used when creating cookies.
-    var ageResults = CartoDbLib.userSelectSQL(ageUserSelections);
-    CartoDbLib.ageSelections = ageResults;
-
-    var langResults = CartoDbLib.userSelectSQL(langUserSelections);
-    CartoDbLib.langSelections = langResults;
-
-    var facilityTypeResults = CartoDbLib.userSelectSQL(typeUserSelections);
-    CartoDbLib.typeSelections = facilityTypeResults;
-
-    var programResults = CartoDbLib.userSelectSQL(programUserSelections);
-    CartoDbLib.programSelections = programResults;
-
-    var insuranceResults = CartoDbLib.userSelectSQL(insuranceUserSelections);
-    CartoDbLib.insuranceSelections = insuranceResults;
-
-    lgbtq_checked = $('#lgbtq').is(':checked')
-    if (lgbtq_checked == true) {
-      CartoDbLib.userSelection += " AND LOWER(specialize_with_lgbtq) LIKE '%yes%'";
-      CartoDbLib.lgbtqSelection = 'true';
-    } else {
-      CartoDbLib.lgbtqSelection = '';
-    }
-
+    // Data for the ADP community sites include only two meaningful columns:
+    // handicap_accessible and accepts_sex_offenders.
+    // A user can limit her search to ADP community sites by checking a box. 
+    // In that case, ignore other filters, e.g., for age or language.
     community_site_checked = $('#communitySite').is(':checked')
     if (community_site_checked == true) {
-      CartoDbLib.userSelection += " AND apd_community_service_site = True";
+      CartoDbLib.userSelection += " AND LOWER(apd_community_service_site) LIKE '%yes%'";
       CartoDbLib.communitySiteSelection = 'true';
-    } else {
+      
+      handicap_accessible_checked = $('#handicapAccessible').is(':checked')
+      if (handicap_accessible_checked == true) {
+        CartoDbLib.userSelection += " AND LOWER(handicap_accessible) LIKE '%yes%'";
+        CartoDbLib.handicapAccessibleSelection = 'true';
+      } else {
+        CartoDbLib.handicapAccessibleSelection = '';
+      }
+
+      accepts_sex_offenders_checked = $('#acceptsSexOffenders').is(':checked')
+      if (accepts_sex_offenders_checked == true) {
+        CartoDbLib.userSelection += " AND LOWER(accepts_sex_offenders) LIKE '%yes%'";
+        CartoDbLib.acceptsSexOffendersSelection = 'true';
+      } else {
+        CartoDbLib.acceptsSexOffendersSelection = '';
+      }
+
+    } 
+    else {
       CartoDbLib.communitySiteSelection = '';
+      CartoDbLib.handicapAccessibleSelection = '';
+      CartoDbLib.acceptsSexOffendersSelection = '';
+      // Gets selected elements in dropdown (represented as an array of objects).
+      var ageUserSelections = ($("#select-age").select2('data'))
+      var langUserSelections = ($("#select-language").select2('data'))
+      var typeUserSelections = ($("#select-type").select2('data'))
+      var programUserSelections = ($("#select-program").select2('data'))
+      var insuranceUserSelections = ($("#select-insurance").select2('data'))
+
+      // Set results equal to varaible – to be used when creating cookies.
+      var ageResults = CartoDbLib.userSelectSQL(ageUserSelections);
+      CartoDbLib.ageSelections = ageResults;
+
+      var langResults = CartoDbLib.userSelectSQL(langUserSelections);
+      CartoDbLib.langSelections = langResults;
+
+      var facilityTypeResults = CartoDbLib.userSelectSQL(typeUserSelections);
+      CartoDbLib.typeSelections = facilityTypeResults;
+
+      var programResults = CartoDbLib.userSelectSQL(programUserSelections);
+      CartoDbLib.programSelections = programResults;
+
+      var insuranceResults = CartoDbLib.userSelectSQL(insuranceUserSelections);
+      CartoDbLib.insuranceSelections = insuranceResults;
+
+      lgbtq_checked = $('#lgbtq').is(':checked')
+      if (lgbtq_checked == true) {
+        CartoDbLib.userSelection += " AND LOWER(specialize_with_lgbtq) LIKE '%yes%'";
+        CartoDbLib.lgbtqSelection = 'true';
+      } else {
+        CartoDbLib.lgbtqSelection = '';
+      }
+
     }
 
     CartoDbLib.whereClause = " WHERE the_geom is not null AND ";

--- a/js/cartodb_lib.js
+++ b/js/cartodb_lib.js
@@ -591,7 +591,9 @@ var CartoDbLib = {
     // handicap_accessible and accepts_sex_offenders.
     // A user can limit her search to ADP community sites by checking a box. 
     // In that case, ignore other filters, e.g., for age or language.
-    community_site_checked = $('#communitySite').is(':checked')
+    community_site_checked = $('li.community-tab').hasClass('active');
+    console.log(community_site_checked, "!!")
+    // community_site_checked = $('#communitySite').is(':checked')
     if (community_site_checked == true) {
       CartoDbLib.ageSelections = '';
       CartoDbLib.langSelections = '';
@@ -768,10 +770,8 @@ var CartoDbLib = {
         }
 
         if (obj.communitySite != '') {
-          $("#communitySite").prop( "checked", true );
-        } else {
-          $("#communitySite").prop( "checked", false );
-        }
+          $('li.community-tab').addClass('active');
+        } 
 
         var ageArr     = CartoDbLib.makeSelectionArray(obj.age, ageOptions);
         $('#select-age').val(ageArr).trigger("change");

--- a/js/cartodb_lib.js
+++ b/js/cartodb_lib.js
@@ -591,10 +591,8 @@ var CartoDbLib = {
     // handicap_accessible and accepts_sex_offenders.
     // A user can limit her search to ADP community sites by checking a box. 
     // In that case, ignore other filters, e.g., for age or language.
-    community_site_checked = $('li.community-tab').hasClass('active');
-    console.log(community_site_checked, "!!")
-    // community_site_checked = $('#communitySite').is(':checked')
-    if (community_site_checked == true) {
+    community_site_clicked = $('li.community-tab').hasClass('active');
+    if (community_site_clicked == true) {
       CartoDbLib.ageSelections = '';
       CartoDbLib.langSelections = '';
       CartoDbLib.typeSelections = '';
@@ -769,9 +767,33 @@ var CartoDbLib = {
           $("#lgbtq").prop( "checked", false );
         }
 
-        if (obj.communitySite != '') {
+        // Activate correct pane
+        console.log($('li.community-tab').hasClass('active'), "communittyyy")
+        if (obj.community != '') {
           $('li.community-tab').addClass('active');
-        } 
+          $('div#community-sites').addClass('active');
+
+          $('li.probation-tab').removeClass('active');
+          $('div#probation').removeClass('active');
+        } else {
+          $('div#probation').addClass('active');
+          $('li.probation-tab').addClass('active');
+
+          $('li.community-tab').removeClass('active');
+          $('div#community-sites').removeClass('active');
+        }
+
+        if (obj.handicap != '') {
+          $("#handicapAccessible").prop( "checked", true );
+        } else {
+          $("#handicapAccessible").prop( "checked", false );
+        }
+
+        if (obj.offenders != '') {
+          $("#acceptsSexOffenders").prop( "checked", true );
+        } else {
+          $("#acceptsSexOffenders").prop( "checked", false );
+        }
 
         var ageArr     = CartoDbLib.makeSelectionArray(obj.age, ageOptions);
         $('#select-age').val(ageArr).trigger("change");

--- a/js/cartodb_lib.js
+++ b/js/cartodb_lib.js
@@ -20,6 +20,7 @@ var CartoDbLib = {
   ageSelections: '',
   langSelections: '',
   typeSelections: '',
+  programSelections: '',
   insuranceSelections: '',
   lgbtqSelection: '',
   communitySiteSelection: '',
@@ -151,23 +152,14 @@ var CartoDbLib = {
           $.address.parameter('address', encodeURIComponent(address));
           $.address.parameter('radius', CartoDbLib.radius);
           CartoDbLib.address = address;
-          // Must call create SQL before setting language parameter.
-          CartoDbLib.createSQL();
-          $.address.parameter('age', encodeURIComponent(CartoDbLib.ageSelections));
-          $.address.parameter('lang', encodeURIComponent(CartoDbLib.langSelections));
-          $.address.parameter('type', encodeURIComponent(CartoDbLib.typeSelections));
-          $.address.parameter('program', encodeURIComponent(CartoDbLib.programSelections));
-          $.address.parameter('insure', encodeURIComponent(CartoDbLib.insuranceSelections));
-          $.address.parameter('lgbtq', encodeURIComponent(CartoDbLib.lgbtqSelection));
-          $.address.parameter('communitySite', encodeURIComponent(CartoDbLib.communitySiteSelection));
-
+          CartoDbLib.createSQL(); // Must call create SQL before setting parameters.
+          CartoDbLib.addUrlParams();
           CartoDbLib.setZoom();
           CartoDbLib.addIcon();
           CartoDbLib.addCircle();
           CartoDbLib.renderMap();
           CartoDbLib.renderList();
           CartoDbLib.getResults();
-
         }
         else {
           alert("We could not find your address: " + status);
@@ -176,16 +168,8 @@ var CartoDbLib = {
     }
     else { //search without geocoding callback
       CartoDbLib.map.setView(new L.LatLng( CartoDbLib.map_centroid[0], CartoDbLib.map_centroid[1] ), CartoDbLib.defaultZoom)
-
-      CartoDbLib.createSQL();
-      $.address.parameter('age', encodeURIComponent(CartoDbLib.ageSelections));
-      $.address.parameter('lang', encodeURIComponent(CartoDbLib.langSelections));
-      $.address.parameter('type', encodeURIComponent(CartoDbLib.typeSelections));
-      $.address.parameter('program', encodeURIComponent(CartoDbLib.programSelections));
-      $.address.parameter('insure', encodeURIComponent(CartoDbLib.insuranceSelections));
-      $.address.parameter('lgbtq', encodeURIComponent(CartoDbLib.lgbtqSelection));
-      $.address.parameter('communitySite', encodeURIComponent(CartoDbLib.communitySiteSelection));
-
+      CartoDbLib.createSQL(); // Must call create SQL before setting parameters.
+      CartoDbLib.addUrlParams();
       CartoDbLib.renderMap();
       CartoDbLib.renderList();
       CartoDbLib.getResults();
@@ -577,6 +561,7 @@ var CartoDbLib = {
 
     $.each( array, function(index, obj) {
       CartoDbLib.userSelection += " AND (LOWER(" + CartoDbLib.addUnderscore(obj.text) + ") LIKE '%yes%' or LOWER(" + CartoDbLib.addUnderscore(obj.text) + ") = 'true')"
+
       results += (obj.text + ", ")
     })
     
@@ -602,6 +587,13 @@ var CartoDbLib = {
     // In that case, ignore other filters, e.g., for age or language.
     community_site_checked = $('#communitySite').is(':checked')
     if (community_site_checked == true) {
+      CartoDbLib.ageSelections = '';
+      CartoDbLib.langSelections = '';
+      CartoDbLib.typeSelections = '';
+      CartoDbLib.programSelections = '';
+      CartoDbLib.insuranceSelections = '';
+      CartoDbLib.lgbtqSelection = '';
+
       CartoDbLib.userSelection += " AND LOWER(apd_community_service_site) LIKE '%yes%'";
       CartoDbLib.communitySiteSelection = 'true';
       
@@ -722,9 +714,11 @@ var CartoDbLib = {
       "language": CartoDbLib.langSelections,
       "type": CartoDbLib.typeSelections,
       "insurance": CartoDbLib.insuranceSelections,
-      "lgbtq": CartoDbLib.lgbtqSelection,
-      "communitySite": CartoDbLib.communitySiteSelection,
       "program": CartoDbLib.programSelections,
+      "lgbtq": CartoDbLib.lgbtqSelection,
+      "community": CartoDbLib.communitySiteSelection,
+      "handicap": CartoDbLib.handicapAccessibleSelection,
+      "offenders": CartoDbLib.acceptsSexOffendersSelection,
       "path": path,
       "save_name": save_name,
     }
@@ -1009,6 +1003,18 @@ var CartoDbLib = {
                cb.apply(this, [xhr.status]);
         }
     });
+  },
+
+  addUrlParams: function() {
+      $.address.parameter('age', encodeURIComponent(CartoDbLib.ageSelections));
+      $.address.parameter('lang', encodeURIComponent(CartoDbLib.langSelections));
+      $.address.parameter('type', encodeURIComponent(CartoDbLib.typeSelections));
+      $.address.parameter('program', encodeURIComponent(CartoDbLib.programSelections));
+      $.address.parameter('insure', encodeURIComponent(CartoDbLib.insuranceSelections));
+      $.address.parameter('lgbtq', encodeURIComponent(CartoDbLib.lgbtqSelection));
+      $.address.parameter('community', encodeURIComponent(CartoDbLib.communitySiteSelection));
+      $.address.parameter('handicap', encodeURIComponent(CartoDbLib.handicapAccessibleSelection));
+      $.address.parameter('offenders', encodeURIComponent(CartoDbLib.acceptsSexOffendersSelection));
   },
 
 }

--- a/js/map.js
+++ b/js/map.js
@@ -12,17 +12,17 @@ $(function() {
   var autocomplete = new google.maps.places.Autocomplete(document.getElementById('search-address'));
   var modalURL;
   
-$('#communitySite').change(function() {
-    // disable filters not relevant to community sites
-    $('#select-age').attr('disabled',this.checked);
-    $('#select-language').attr('disabled',this.checked);
-    $('#select-type').attr('disabled',this.checked);
-    $('#select-program').attr('disabled',this.checked);
-    $('#select-insurance').attr('disabled',this.checked);
-    $('#lgbtq').attr('disabled',this.checked);
-});
+  $('#communitySite').change(function() {
+      // disable filters not relevant to community sites
+      $('#select-age').attr('disabled',this.checked);
+      $('#select-language').attr('disabled',this.checked);
+      $('#select-type').attr('disabled',this.checked);
+      $('#select-program').attr('disabled',this.checked);
+      $('#select-insurance').attr('disabled',this.checked);
+      $('#lgbtq').attr('disabled',this.checked);
 
-
+      $('.apd-filters').toggleClass('hidden')
+  });
 
   $('#btnReset').tooltip();
   $('#btnViewMode').tooltip();

--- a/js/map.js
+++ b/js/map.js
@@ -9,11 +9,12 @@ $(function() {
   // https://github.com/Aleksander98/bsgdprcookies
   // settings for jquery.bs.gdpr.cookies.js
   var settings = {
-      message: 'Probation Community Resources uses cookies to help save your searches for easy retrieval. By using this site you consent to our cookie policy.',
+      title: 'About our cookies',
+      message: 'Probation Community Resources uses cookies. Cookies enable the "Save search" functionality, which lets you save your favorite searches for easy retrieval: DataMade does not collect or use this data in any way. By using this site you consent to our cookie policy.',
       moreLinkLabel: '',
       messageMaxHeightPercent: 30,
-      moreLink: '/privacy/',
-      delay: 1000,
+      delay: 250,
+      acceptButtonLabel: 'Continue',
       allowAdvancedOptions: false,
       OnAccept : function() {
           var preferences = $.fn.bsgdprcookies.GetUserPreferences();

--- a/js/map.js
+++ b/js/map.js
@@ -20,8 +20,8 @@ $(function() {
       $('#select-program').attr('disabled',this.checked);
       $('#select-insurance').attr('disabled',this.checked);
       $('#lgbtq').attr('disabled',this.checked);
-
-      $('.apd-filters').toggleClass('hidden')
+      // show/hide the APD community site filters
+      $('.apd-filters').toggleClass('hidden');
   });
 
   $('#btnReset').tooltip();

--- a/js/map.js
+++ b/js/map.js
@@ -10,7 +10,7 @@ $(function() {
   // settings for jquery.bs.gdpr.cookies.js
   var settings = {
       title: 'About our cookies',
-      message: 'Probation Community Resources uses cookies. Cookies enable the "Save search" functionality, which lets you save your favorite searches for easy retrieval: DataMade does not collect or use this data in any way. By using this site you consent to our cookie policy.',
+      message: 'Probation Community Resources uses cookies to allow you to save your searches for easy retrieval. DataMade does not collect or use this data in any way. By using this site you consent to our cookie policy.'
       moreLinkLabel: '',
       messageMaxHeightPercent: 30,
       delay: 250,

--- a/js/map.js
+++ b/js/map.js
@@ -10,7 +10,7 @@ $(function() {
   // settings for jquery.bs.gdpr.cookies.js
   var settings = {
       title: 'About our cookies',
-      message: 'Probation Community Resources uses cookies to allow you to save your searches for easy retrieval. DataMade does not collect or use this data in any way. By using this site you consent to our cookie policy.'
+      message: 'Probation Community Resources uses cookies to allow you to save your searches for easy retrieval. DataMade does not collect or use this data in any way. By using this site you consent to our cookie policy.',
       moreLinkLabel: '',
       messageMaxHeightPercent: 30,
       delay: 250,

--- a/js/map.js
+++ b/js/map.js
@@ -11,6 +11,18 @@ $(function() {
 
   var autocomplete = new google.maps.places.Autocomplete(document.getElementById('search-address'));
   var modalURL;
+  
+$('#communitySite').change(function() {
+    // disable filters not relevant to community sites
+    $('#select-age').attr('disabled',this.checked);
+    $('#select-language').attr('disabled',this.checked);
+    $('#select-type').attr('disabled',this.checked);
+    $('#select-program').attr('disabled',this.checked);
+    $('#select-insurance').attr('disabled',this.checked);
+    $('#lgbtq').attr('disabled',this.checked);
+});
+
+
 
   $('#btnReset').tooltip();
   $('#btnViewMode').tooltip();

--- a/js/map.js
+++ b/js/map.js
@@ -6,6 +6,25 @@ $(window).resize(function () {
 }).resize();
 
 $(function() {
+  // https://github.com/Aleksander98/bsgdprcookies
+  // settings for jquery.bs.gdpr.cookies.js
+  var settings = {
+      message: 'Probation Community Resources uses cookies to help save your searches for easy retrieval. By using this site you consent to our cookie policy.',
+      moreLinkLabel: '',
+      messageMaxHeightPercent: 30,
+      moreLink: '/privacy/',
+      delay: 1000,
+      allowAdvancedOptions: false,
+      OnAccept : function() {
+          var preferences = $.fn.bsgdprcookies.GetUserPreferences();
+      }
+  }
+  // events for jquery.bs.gdpr.cookies.js
+  $('body').bsgdprcookies(settings);
+  $('#cookiesBtn').on('click', function(){
+      $('body').bsgdprcookies(settings, 'reinit');
+  });
+
   CartoDbLib.initialize();
   new Clipboard('#copy-button');
 

--- a/js/map.js
+++ b/js/map.js
@@ -40,8 +40,6 @@ $(function() {
       $('#select-program').attr('disabled',this.checked);
       $('#select-insurance').attr('disabled',this.checked);
       $('#lgbtq').attr('disabled',this.checked);
-      // show/hide the community site filters
-      $('.community-service-filters').toggleClass('hidden');
   });
 
   $('#btnReset').tooltip();

--- a/js/map.js
+++ b/js/map.js
@@ -40,8 +40,8 @@ $(function() {
       $('#select-program').attr('disabled',this.checked);
       $('#select-insurance').attr('disabled',this.checked);
       $('#lgbtq').attr('disabled',this.checked);
-      // show/hide the APD community site filters
-      $('.apd-filters').toggleClass('hidden');
+      // show/hide the community site filters
+      $('.community-service-filters').toggleClass('hidden');
   });
 
   $('#btnReset').tooltip();

--- a/lib/jquery.bs.gdpr.cookies.js
+++ b/lib/jquery.bs.gdpr.cookies.js
@@ -1,0 +1,289 @@
+/*!
+ * Name: Bootstrap GDPR Cookies
+ * Description: jQuery based plugin that shows bootstrap modal with cookie info
+ * Version: v1.0
+ *
+ * Copyright (c) 2018 Aleksander Woźnica
+ * Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
+ * Inspired by: https://github.com/ketanmistry/ihavecookies
+ * Cookies Create/Read/Delete from https://www.quirksmode.org/js/cookies.html
+ */
+
+(function($) {
+
+    $.fn.bsgdprcookies = function(options, event) {
+
+        var $element = $(this);
+        var cookieShow = ReadCookie('CookieShow');
+        var cookiePreferences = ReadCookie('CookiePreferences');
+
+        // Set default settings
+        var settings = $.extend({
+            id: 'bs-gdpr-cookies-modal',
+            class: '',
+            title: 'Cookies & Privacy Policy',
+            backdrop: 'static',
+            message: 'Your cookie message...',
+            messageScrollBar: false,
+            messageMaxHeightPercent: 25,
+            delay: 1500,
+            expireDays: 30,
+            moreLinkActive: true,
+            moreLinkLabel: 'More informations..',
+            moreLinkNewTab: true,
+            moreLink: 'privacy-policy.php',
+            acceptButtonLabel: 'Accept',
+            allowAdvancedOptions: false,
+            advancedTitle: 'Select which cookies you want to accept',
+            advancedAutoOpenDelay: 1000,
+            advancedButtonLabel: 'Customize',
+            advancedCookiesToSelect: [
+                {
+                    name: 'necessary',
+                    title: 'Necessary',
+                    description: 'Required for the site to work properly',
+                    isFixed: true
+                },
+                {
+                    name: 'preferences',
+                    title: 'Site Preferences',
+                    description: 'Required for saving your site preferences, e.g. remembering your username etc.',
+                    isFixed: false
+                },
+                {
+                    name: 'analytics',
+                    title: 'Analytics',
+                    description: 'Required to collect site visits, browser types, etc.',
+                    isFixed: false
+                },
+                {
+                    name: 'marketing',
+                    title: 'Marketing',
+                    description: 'Required to marketing, e.g. newsletters, social media, etc',
+                    isFixed: false
+                }
+            ],
+            OnAccept: function() {}
+        }, options);
+
+        if(!cookieShow || !cookiePreferences || event == 'reinit') {
+
+            // Make sure that other instances are gone
+            DisposeModal(settings.id);
+
+            var modalBody = '';
+            var modalButtons = '';
+            var modalBodyStyle = '';
+            var moreLink = '';
+
+            // Generate more link
+            if(settings.moreLinkActive == true) {
+                if(settings.moreLinkNewTab == true) {
+                    moreLink = '<a href="' + settings.moreLink + '" target="_blank" rel="noopener noreferrer" id="' + settings.id + '-more-link">' + settings.moreLinkLabel + '</a>';
+                }
+                else {
+                    moreLink = '<a href="' + settings.moreLink + '" id="' + settings.id + '-more-link">' + settings.moreLinkLabel + '</a>';
+                }
+            }
+
+
+            if(settings.allowAdvancedOptions === true) {
+                modalButtons = '<button id="' + settings.id + '-advanced-btn" type="button" class="btn btn-secondary">' + settings.advancedButtonLabel + '</button><button id="' + settings.id + '-accept-btn" type="button" class="btn btn-primary" data-dismiss="modal">' + settings.acceptButtonLabel + '</button>';
+
+                // Generate list of available advanced settings
+                var advancedCookiesToSelectList = '';
+
+                preferences = JSON.parse(cookiePreferences);
+                $.each(settings.advancedCookiesToSelect, function(index, field) {
+                    if (field.name !== '' && field.title !== '') {
+
+                        var cookieDisabledText = '';
+                        if(field.isFixed == true) {
+                            cookieDisabledText = ' checked="checked" disabled="disabled"';
+                        }       
+
+                        var cookieDescription = '';
+                        if (field.description !== false) {
+                            cookieDescription = ' title="' + field.description + '"';
+                        }
+
+                        var fieldID = settings.id + '-option-' + field.name;
+
+                        advancedCookiesToSelectList += '<li><input type="checkbox" id="' + fieldID + '" name="bsgdpr[]" value="' + field.name + '" data-auto="on" ' + cookieDisabledText + '> <label name="bsgdpr[]" data-toggle="tooltip" data-placement="right" for="' + fieldID + '"' + cookieDescription + '>' + field.title + '</label></li>';
+                    }
+                });
+
+                modalBody = '<div id="' + settings.id + '-message">' + settings.message + moreLink + '</div>' + '<div id="' + settings.id + '-advanced-types" style="display:none; margin-top: 10px;"><h5 id="' + settings.id + '-advanced-title">' + settings.advancedTitle + '</h5>' + advancedCookiesToSelectList + '</div>';
+            }
+            else {
+                modalButtons = '<button id="' + settings.id + '-accept-btn" type="button" class="btn btn-primary" data-dismiss="modal">' + settings.acceptButtonLabel + '</button>';
+
+                modalBody ='<div id="' + settings.id + '-message">' + settings.message + moreLink + '</div>';
+            }
+            
+            if(settings.messageScrollBar == true) {
+                modalBodyStyle = 'style="overflow-y: scroll; max-height: ' + settings.messageMaxHeightPercent + '%"';
+            }
+
+            var modal = '<div class="modal fade ' + settings.class + '" id="' + settings.id + '" tabindex="-1" role="dialog" aria-labelledby="' + settings.id + '-title" aria-hidden="true"><div class="modal-dialog modal-dialog-centered" role="document"><div class="modal-content"><div class="modal-header"><h5 class="modal-title" id="' + settings.id + '-title">' + settings.title + '</h5></div><div id="' + settings.id + '-body" class="modal-body" ' + modalBodyStyle + '>' + modalBody + '</div><div class="modal-footer">' + modalButtons + '</div></div></div></div>';
+
+            // Show Modal
+            setTimeout(function() {
+                $($element).append(modal);
+
+                $('#' + settings.id).modal({keyboard: false, backdrop: settings.backdrop});
+
+                if (event === 'reinit' && settings.allowAdvancedOptions === true) {
+
+                    setTimeout(function(){
+                        $('#' + settings.id + '-advanced-btn').trigger('click');
+                        $.each(preferences, function(index, field) {
+                            $('#' + settings.id + '-option-' + field).prop('checked', true);
+                        });
+                    }, settings.advancedAutoOpenDelay)
+                }
+            }, settings.delay);
+
+            // When user clicks accept set cookie and close modal
+            $('body').on('click','#' + settings.id + '-accept-btn', function(){
+
+                // Set show cookie
+                CreateCookie('CookieShow', true, settings.expireDays);
+                DisposeModal(settings.id);
+
+                // If 'data-auto' is set to ON, tick all checkboxes because the user has not chosen any option
+                $('input[name="bsgdpr[]"][data-auto="on"]').prop('checked', true);
+
+                // Clear user preferences cookie
+                DeleteCookie('CookiePreferences');
+
+                // Set user preferences cookie
+                var preferences = [];
+                $.each($('input[name="bsgdpr[]"]').serializeArray(), function(i, field){
+                    preferences.push(field.value);
+                });
+                CreateCookie('CookiePreferences', JSON.stringify(preferences), 365);
+
+                // Run callback function
+                settings.OnAccept.call(this);
+            });
+
+            // Show advanced options
+            $('body').on('click', '#' + settings.id + '-advanced-btn', function(){
+                // Uncheck all checkboxes except for the disabled ones
+                $('input[name="bsgdpr[]"]:not(:disabled)').attr('data-auto', 'off').prop('checked', false);
+                
+                $('label[name="bsgdpr[]"]').tooltip({offset: '0, 10'});
+
+                // Show advanced checkboxes
+                $('#' + settings.id + '-advanced-types').slideDown('fast', function(){
+                    $('#' + settings.id + '-advanced-btn').prop('disabled', true);
+                });
+
+                // Scroll content to bottom if scrollbar option is active
+                if(settings.messageScrollBar == true) {
+                    setTimeout(function() {
+                        bodyID = settings.id + '-body';
+                        var div = document.getElementById(bodyID);
+                        $('#' + bodyID).animate({
+                            scrollTop: div.scrollHeight - div.clientHeight
+                        }, 800);
+                    }, 500);
+                }
+            });
+        }
+        else {
+            var cookieValue = true;
+            if (cookieShow == 'false') {
+                cookieValue = false;
+            }
+            CreateCookie('CookieShow', cookieValue, settings.expireDays);
+            DisposeModal(settings.id);
+        }
+    }
+
+    /**
+     * Returns user preferences saved in cookie
+     */
+    $.fn.bsgdprcookies.GetUserPreferences = function() {
+        var preferences = ReadCookie('CookiePreferences');
+        return JSON.parse(preferences);
+    };
+
+    /**
+     * Check if user preference exists in cookie
+     * 
+     * @param {string} pref Preference to check
+     */
+    $.fn.bsgdprcookies.PreferenceExists = function(pref) {
+        var preferences = $.fn.bsgdprcookies.GetUserPreferences();
+
+        if (ReadCookie('CookieShow') === false) {
+            return false;
+        }
+        if (preferences === false || preferences.indexOf(pref) === -1) {
+            return false;
+        }
+
+        return true;
+    };
+
+
+    /**
+     * Hide then delete bs modal
+     * 
+     * @param {string} id Modal ID without '#'
+     */
+    function DisposeModal(id) {
+        id = '#' + id;
+        $(id).modal('hide');
+        $(id).on('hidden.bs.modal', function (e) {
+            $(this).modal('dispose');
+            $(id).remove();
+        });
+    }
+
+    /**
+     * Sets Cookie
+     * 
+     * @param {string} name Name of the cookie which you want to create
+     * @param {boolean} value Value for the created cookie
+     * @param {number} days Expire days
+     */
+    function CreateCookie(name, value, days) {
+        if (days) {
+            var date = new Date();
+            date.setTime(date.getTime() + (days*24*60*60*1000));
+            var expires = "; expires=" + date.toGMTString();
+        }
+        else var expires = "";
+        document.cookie = name + "=" + value + expires + "; path=/";
+    }
+    
+
+    /**
+     * Gets Cookie called 'name'
+     * 
+     * @param {string} name Name of the cookie to read
+     */
+    function ReadCookie(name) {
+        var nameEQ = name + "=";
+        var ca = document.cookie.split(';');
+        for(var i=0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+            if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+        }
+        return null;
+    }
+    
+    /**
+     * Deletes Cookie called 'name;
+     * 
+     * @param {string} name Name of the cookie which you want to delete
+     */
+    function DeleteCookie(name) {
+        CreateCookie(name, "", -1);
+    }    
+
+}(jQuery));


### PR DESCRIPTION
This PR adds filtering options for APD community service sites (recently added to the PRM Google sheet). I followed the patterns in the original implementation, i.e., did not do much refactoring of the codebase.

I also added GDPR compliance message – [made easy with this library.](https://github.com/Aleksander98/bsgdprcookies)

What needs review?
* The code itself, of course.
* I would welcome feedback on the adjusted UI. A user cannot add certain filters, if they want to search for APD resources: I disabled those filters when a user checks "Show only APD community service sites." Is this clear?
* How does the GDPR message sound? 
